### PR TITLE
Add padded SHA-256 hex utility

### DIFF
--- a/docs/sha256_difference.md
+++ b/docs/sha256_difference.md
@@ -1,0 +1,7 @@
+# Sha256MessageDigest와 Sha256Vanilla 비교
+
+두 구현은 모두 SHA-256 해시 값을 계산하지만 방식이 다릅니다.
+
+* `Sha256Vanilla`는 KISA에서 제공한 레퍼런스 코드를 그대로 옮긴 순수 자바 구현입니다. 내부적으로 상태를 관리하며 직접 라운드를 수행합니다.
+* `Sha256MessageDigest`는 JDK의 `MessageDigest` 클래스를 사용합니다. JDK가 제공하는 최적화된 구현을 그대로 활용하므로 코드가 간단하며 성능이 좋습니다.
+* 두 클래스 모두 동일한 바이트 배열을 반환한다. 하지만 `Sha256Vanilla.encrypt(byte[])` 메서드는 각 바이트를 패딩 없이 16진수 문자열로 변환하기 때문에 길이가 변동될 수 있다. 이에 비해 `Sha256MessageDigest.encrypt(byte[])`는 두 자리로 패딩해 64자리 16진수 문자열을 반환한다.

--- a/lib/src/main/java/me/totoku103/crypto/kisa/sha2/model/Sha256MessageDigest.java
+++ b/lib/src/main/java/me/totoku103/crypto/kisa/sha2/model/Sha256MessageDigest.java
@@ -1,0 +1,82 @@
+package me.totoku103.crypto.kisa.sha2.model;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * JDK MessageDigest를 이용해 SHA-256 해시를 계산합니다.
+ */
+public class Sha256MessageDigest {
+
+    private static final int OK = 0;
+    private static final int PARAMETER_ERROR = 1;
+
+    /**
+     * JDK에서 SHA-256 알고리즘 지원 여부를 확인합니다.
+     */
+    public static boolean isSha256Available() {
+        try {
+            MessageDigest.getInstance("SHA-256");
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+
+    /**
+     * SHA-256 해시를 계산해 주어진 버퍼에 결과를 저장합니다.
+     *
+     * @param output   결과 버퍼
+     * @param outLen   출력 길이(byte)
+     * @param input    입력 데이터
+     * @param inLen    입력 길이
+     * @return 성공하면 0, 실패하면 1
+     */
+    public int sha256Hash(final byte[] output, final int outLen, final byte[] input, final int inLen) {
+        try {
+            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(input, 0, inLen);
+            final byte[] digest = md.digest();
+            if (digest.length != outLen) {
+                return PARAMETER_ERROR;
+            }
+            System.arraycopy(digest, 0, output, 0, outLen);
+            return OK;
+        } catch (NoSuchAlgorithmException e) {
+            return PARAMETER_ERROR;
+        }
+    }
+
+    /**
+     * 새 배열로 해시 값을 돌려줍니다.
+     */
+    public byte[] toHash(final byte[] input) {
+        try {
+            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return md.digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("Unsupported SHA-256", e);
+        }
+    }
+
+    /**
+     * 입력 데이터를 SHA-256으로 해싱하여 64자리 16진수 문자열을 반환한다.
+     * <p>
+     * 기존 {@link Sha256Vanilla#encrypt(byte[])} 는 각 바이트에 0 패딩을 하지 않아
+     * 문자열 길이가 달라질 수 있다. 이 메서드는 0 패딩을 적용하여 일반적인 결과와
+     * 동일한 형식을 제공한다.
+     * </p>
+     *
+     * @param input 입력 데이터
+     * @return 64자리 16진수 해시 문자열
+     */
+    public String encrypt(final byte[] input) {
+        final byte[] digest = toHash(input);
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : digest) {
+            // Sha256Vanilla는 패딩이 없으나 여기서는 두 자리로 고정한다.
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+}

--- a/lib/src/test/java/me/totoku103/crypto/kisa/sha2/model/Sha256MessageDigestTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/sha2/model/Sha256MessageDigestTest.java
@@ -1,0 +1,45 @@
+package me.totoku103.crypto.kisa.sha2.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.security.MessageDigest;
+
+class Sha256MessageDigestTest {
+
+    @Test
+    void compareWithJdk() throws Exception {
+        String message = "message";
+        Sha256MessageDigest md = new Sha256MessageDigest();
+        byte[] result = md.toHash(message.getBytes());
+
+        MessageDigest jdk = MessageDigest.getInstance("SHA-256");
+        byte[] expected = jdk.digest(message.getBytes());
+        Assertions.assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void hexStringWithPadding() throws Exception {
+        String message = "message";
+        Sha256MessageDigest md = new Sha256MessageDigest();
+        String hex = md.encrypt(message.getBytes());
+
+        MessageDigest jdk = MessageDigest.getInstance("SHA-256");
+        StringBuilder sb = new StringBuilder();
+        for (byte b : jdk.digest(message.getBytes())) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        Assertions.assertEquals(sb.toString(), hex);
+    }
+
+    @Test
+    void compareWithVanilla() {
+        String message = "message";
+        Sha256MessageDigest md = new Sha256MessageDigest();
+        byte[] result = md.toHash(message.getBytes());
+
+        byte[] vanilla = new byte[32];
+        Sha256Vanilla.encrypt(message.getBytes(), message.length(), vanilla);
+        Assertions.assertArrayEquals(vanilla, result);
+    }
+}


### PR DESCRIPTION
## Summary
- Sha256Vanilla는 바이트 단위 패딩 없이 16진수 문자열을 반환한다는 점을 문서에 명시
- Sha256MessageDigest에 패딩을 적용한 `encrypt(byte[])` 메서드 추가
- Sha256Vanilla의 원래 구현으로 되돌리고 테스트 수정
- Sha256MessageDigestTest에 패딩 확인 테스트 추가

## Testing
- `./gradlew test` *(fails: Cannot find a Java toolchain)*
- `./gradlew check` *(fails: Cannot find a Java toolchain)*


------
https://chatgpt.com/codex/tasks/task_e_6842601019b483219522654400d6f344