### PR TITLE
Improve test names and DisplayNames

### DIFF
--- a/lib/src/test/java/me/totoku103/crypto/java/sha3/Sha3Test.java
+++ b/lib/src/test/java/me/totoku103/crypto/java/sha3/Sha3Test.java
@@ -25,8 +25,8 @@ class Sha3Test {
     }
 
     @Test
-    @DisplayName("BitSizeType별 MessageDigest 인스턴스 생성 가능 여부 검증")
-    public void testMessageDigestInstanceCreationByBitSizeType() {
+    @DisplayName("모든 Sha3AlgorithmType에 대해 MessageDigest 인스턴스가 생성되는지 확인")
+    public void shouldCreateMessageDigestInstancesForAllBitSizes() {
         Assumptions.assumeTrue(Sha3.isSha3Available(Sha3AlgorithmType.SHA3_224));
 
         Arrays.asList(Sha3AlgorithmType.values())
@@ -42,8 +42,8 @@ class Sha3Test {
     }
 
     @Test
-    @DisplayName("한글 입력 SHA3-512(최적화, 지원 시 실행)")
-    public void testOptimizedKorean512() {
+    @DisplayName("지원되는 경우 최적화된 SHA3-512 구현으로 한글 문자열을 해싱하여 예상 값과 비교")
+    public void shouldHashKoreanTextWithOptimizedSha3512() {
         Assumptions.assumeTrue(Sha3.isSha3Available(Sha3AlgorithmType.SHA3_512));
 
         final me.totoku103.crypto.java.sha3.Sha3 javaSha3 = new me.totoku103.crypto.java.sha3.Sha3();
@@ -56,8 +56,8 @@ class Sha3Test {
     }
 
     @Test
-    @DisplayName("이모지 입력 비교 (최적화 지원 시 실행)")
-    public void testUnicodeOptimizedMatchesOriginal() {
+    @DisplayName("이모지 문자열을 사용해 최적화 구현과 기본 구현의 SHA3-256 결과가 동일한지 확인")
+    public void optimizedSha3256ShouldMatchOriginalForEmoji() {
         Assumptions.assumeTrue(Sha3.isSha3Available(Sha3AlgorithmType.SHA3_256));
 
         final me.totoku103.crypto.kisa.sha3.Sha3 kisaSha3 = new me.totoku103.crypto.kisa.sha3.Sha3();
@@ -73,8 +73,8 @@ class Sha3Test {
     }
 
     @Test
-    @DisplayName("모든 비트 크기 일치 테스트 (최적화 지원 시 실행)")
-    public void testAllBitSizesMatch() {
+    @DisplayName("최적화 구현이 모든 비트 크기에서 참조 구현과 동일한 해시를 생성하는지 검증")
+    public void optimizedAndReferenceMatchForAllBitSizes() {
         Assumptions.assumeTrue(Sha3.isSha3Available(Sha3AlgorithmType.SHA3_256));
 
         final me.totoku103.crypto.kisa.sha3.Sha3 kisaSha3 = new me.totoku103.crypto.kisa.sha3.Sha3();
@@ -93,8 +93,8 @@ class Sha3Test {
     }
 
     @Test
-    @DisplayName("최적화 버전 결과 비교 (SHA3-256 지원 시에만 실행)")
-    public void testKISAMatchesJava() {
+    @DisplayName("최적화된 SHA3-256 결과가 KISA 구현과 완전히 일치하는지 검증")
+    public void optimizedSha3256MatchesKisaImplementation() {
         Assumptions.assumeTrue(Sha3.isSha3Available(Sha3AlgorithmType.SHA3_256));
 
         final me.totoku103.crypto.kisa.sha3.Sha3 kisaSha3 = new me.totoku103.crypto.kisa.sha3.Sha3();

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaCasesTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaCasesTest.java
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AriaCasesTest {
 
     @Test
-    @DisplayName("여러 키 길이에 대한 암복호 라운드트립")
-    void testRoundTrip() throws InvalidKeyException {
+    @DisplayName("128/192/256비트 키로 암호화 후 복호화하여 원문이 유지되는지 확인")
+    void roundTripShouldWorkForDifferentKeySizes() throws InvalidKeyException {
         final String[][] vectors = {
                 {"128", "000102030405060708090a0b0c0d0e0f", "00112233445566778899aabbccddeeff"},
                 {"192", "000102030405060708090a0b0c0d0e0f1011121314151617", "00112233445566778899aabbccddeeff"},
@@ -36,14 +36,14 @@ class AriaCasesTest {
     }
 
     @Test
-    @DisplayName("잘못된 키 사이즈 예외 확인")
-    void testInvalidKeySize() {
+    @DisplayName("지원하지 않는 키 길이를 사용하면 InvalidKeyException이 발생해야 한다")
+    void invalidKeySizeShouldThrowException() {
         assertThrows(InvalidKeyException.class, () -> new Aria(100));
     }
 
     @Test
-    @DisplayName("키 설정 없이 암호화 시 예외")
-    void testEncryptWithoutKey() throws InvalidKeyException {
+    @DisplayName("키를 설정하지 않고 암호화하면 InvalidKeyException이 발생해야 한다")
+    void encryptWithoutKeyShouldThrowException() throws InvalidKeyException {
         final Aria aria = new Aria(128);
         final byte[] plain = new byte[16];
         final byte[] out = new byte[16];
@@ -51,16 +51,16 @@ class AriaCasesTest {
     }
 
     @Test
-    @DisplayName("짧은 키 입력시 예외")
-    void testShortKey() throws InvalidKeyException {
+    @DisplayName("키 길이가 부족할 때 setKey가 InvalidKeyException을 발생해야 한다")
+    void shortKeyShouldThrowException() throws InvalidKeyException {
         final Aria aria = new Aria(256);
         final byte[] shortKey = new byte[16];
         assertThrows(InvalidKeyException.class, () -> aria.setKey(shortKey));
     }
 
     @Test
-    @DisplayName("reset 후 재사용 확인")
-    void testReuseAfterReset() throws InvalidKeyException {
+    @DisplayName("reset 호출 후 다른 키 길이를 설정해도 정상적으로 동작해야 한다")
+    void shouldReuseAfterReset() throws InvalidKeyException {
         final Aria aria = new Aria(128);
         final byte[] key1 = ConvertUtils.fromHex("000102030405060708090a0b0c0d0e0f");
         final byte[] plain = ConvertUtils.fromHex("00112233445566778899aabbccddeeff");

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaEngineTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaEngineTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 class AriaEngineTest {
 
     @Test
-    @DisplayName("새 구현과 기존 구현 비교")
-    public void testEngineMatchesOriginal() throws InvalidKeyException {
+    @DisplayName("새로운 ARIA 엔진 구현이 기존 구현과 동일한 결과를 생성하는지 검증")
+    public void engineShouldMatchReferenceImplementation() throws InvalidKeyException {
         final byte[] key = ConvertUtils.fromHex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
         final byte[] plain = ConvertUtils.fromHex("00112233445566778899aabbccddeeff");
 

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/AriaTest.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AriaTest {
 
     @Test
-    @DisplayName("RFC5794 공식 벡터 검증")
-    public void testOfficialVectors() throws InvalidKeyException {
+    @DisplayName("RFC5794에 정의된 ARIA 공식 테스트 벡터로 암복호화가 올바르게 수행되는지 확인")
+    public void shouldMatchRfc5794OfficialVectors() throws InvalidKeyException {
         final String[][] vectors = {
                 {
                         "128",
@@ -89,8 +89,8 @@ class AriaTest {
 
     @ParameterizedTest(name = "[{index}] {0}-bit key – ECB round‑trip")
     @MethodSource("testVectors")
-    @DisplayName("ARIA official ECB test vectors encrypt/decrypt round‑trip")
-    void ecbVectorsShouldMatchSpec(int keySize, String keyHex, String ptHex, String ctHex) throws InvalidKeyException {
+    @DisplayName("ARIA 공식 ECB 테스트 벡터로 암호화 후 복호화하면 원문이 동일하게 복원되는지 검증")
+    void roundTripMatchesOfficialEcbVectors(int keySize, String keyHex, String ptHex, String ctHex) throws InvalidKeyException {
         Aria aria = new Aria(keySize);
         aria.setKey(ConvertUtils.fromHex(keyHex));
 

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaCbcTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaCbcTest.java
@@ -41,8 +41,8 @@ public class AriaCbcTest {
 
     @ParameterizedTest(name = "[{index}] {0}-bit key – CBC mode with fixed IV")
     @MethodSource("cbcTestVectors")
-    @DisplayName("ARIA CBC mode encryption/decryption with fixed IV")
-    void testCbcWithFixedIv(int keySize, String keyHex, String ptHex, String ctHex) throws InvalidKeyException {
+    @DisplayName("고정된 IV를 사용한 CBC 모드 암복호화가 테스트 벡터와 일치하는지 확인")
+    void cbcWithFixedIvShouldMatchVectors(int keySize, String keyHex, String ptHex, String ctHex) throws InvalidKeyException {
         byte[] key = ConvertUtils.fromHex(keyHex);
         byte[] plain = ConvertUtils.fromHex(ptHex);
         byte[] expected = ConvertUtils.fromHex(ctHex);

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaModeVectorsTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaModeVectorsTest.java
@@ -91,8 +91,8 @@ public class AriaModeVectorsTest {
     private static final byte[] CT_CTR = ConvertUtils.fromHex("3720e53ba7d615383406b09f0a05a2001673032f1d03d982e5671311789b6f4ab461748f2f56718727d7a084f1499d101c9e2d05a74a5eeb00c27c811490ae5381e9e3b57b24a361adfd3706cd39c265bdbfb65d1c84ef37e4f6b8b58ac6dd628ae47c6115c6a581fb66706735080b4c336190a6e1e0d43e79ee0dad09faa9270dc680c2197f4cd164f9e92985dbcab8df1eefc2069f96c1825fe5fd561f0d20");
 
     @Test
-    @DisplayName("ECB vector")
-    void ecbVector() {
+    @DisplayName("ECB 모드 공식 테스트 벡터와 일치하는지 검증")
+    void ecbVectorShouldMatchReference() {
         BlockCipher engine = new AriaBcBlockCipher();
         engine.init(true, new KeyParameter(KEY));
         byte[] out = new byte[PLAINTEXT.length];
@@ -110,8 +110,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CBC vector")
-    void cbcVector() {
+    @DisplayName("CBC 모드 공식 테스트 벡터와 일치하는지 검증")
+    void cbcVectorShouldMatchReference() {
         byte[] cipher = AriaModes.encryptCbc(KEY, IV, PLAINTEXT);
         assertArrayEquals(CT_CBC, cipher);
         byte[] plain = AriaModes.decryptCbc(KEY, IV, cipher);
@@ -119,8 +119,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CFB-128 vector")
-    void cfb128Vector() {
+    @DisplayName("CFB-128 모드 테스트 벡터와 결과가 동일해야 한다")
+    void cfb128VectorShouldMatchReference() {
         byte[] cipher = AriaModes.encryptCfb(KEY, IV, PLAINTEXT, 128);
         assertArrayEquals(CT_CFB128, cipher);
         byte[] plain = AriaModes.decryptCfb(KEY, IV, cipher, 128);
@@ -128,8 +128,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CFB-64 vector")
-    void cfb64Vector() {
+    @DisplayName("CFB-64 모드 테스트 벡터와 결과가 동일해야 한다")
+    void cfb64VectorShouldMatchReference() {
         byte[] cipher = AriaModes.encryptCfb(KEY, IV, PLAINTEXT, 64);
         assertArrayEquals(CT_CFB64, cipher);
         byte[] plain = AriaModes.decryptCfb(KEY, IV, cipher, 64);
@@ -137,8 +137,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CFB-16 vector")
-    void cfb16Vector() {
+    @DisplayName("CFB-16 모드 테스트 벡터와 결과가 동일해야 한다")
+    void cfb16VectorShouldMatchReference() {
         byte[] cipher = AriaModes.encryptCfb(KEY, IV, PLAINTEXT, 16);
         assertArrayEquals(CT_CFB16, cipher);
         byte[] plain = AriaModes.decryptCfb(KEY, IV, cipher, 16);
@@ -146,8 +146,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CFB-8 vector")
-    void cfb8Vector() {
+    @DisplayName("CFB-8 모드 테스트 벡터와 결과가 동일해야 한다")
+    void cfb8VectorShouldMatchReference() {
         byte[] cipher = AriaModes.encryptCfb(KEY, IV, PLAINTEXT, 8);
         assertArrayEquals(CT_CFB8, cipher);
         byte[] plain = AriaModes.decryptCfb(KEY, IV, cipher, 8);
@@ -155,8 +155,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("OFB-128 vector")
-    void ofb128Vector() {
+    @DisplayName("OFB-128 모드 테스트 벡터와 결과가 동일해야 한다")
+    void ofb128VectorShouldMatchReference() {
         byte[] cipher = AriaModes.processOfb(KEY, IV, PLAINTEXT, 128);
         assertArrayEquals(CT_OFB128, cipher);
         byte[] plain = AriaModes.processOfb(KEY, IV, cipher, 128);
@@ -164,8 +164,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("OFB-64 vector")
-    void ofb64Vector() {
+    @DisplayName("OFB-64 모드 테스트 벡터와 결과가 동일해야 한다")
+    void ofb64VectorShouldMatchReference() {
         byte[] cipher = AriaModes.processOfb(KEY, IV, PLAINTEXT, 64);
         assertArrayEquals(CT_OFB64, cipher);
         byte[] plain = AriaModes.processOfb(KEY, IV, cipher, 64);
@@ -173,8 +173,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("OFB-16 vector")
-    void ofb16Vector() {
+    @DisplayName("OFB-16 모드 테스트 벡터와 결과가 동일해야 한다")
+    void ofb16VectorShouldMatchReference() {
         byte[] cipher = AriaModes.processOfb(KEY, IV, PLAINTEXT, 16);
         assertArrayEquals(CT_OFB16, cipher);
         byte[] plain = AriaModes.processOfb(KEY, IV, cipher, 16);
@@ -182,8 +182,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("OFB-8 vector")
-    void ofb8Vector() {
+    @DisplayName("OFB-8 모드 테스트 벡터와 결과가 동일해야 한다")
+    void ofb8VectorShouldMatchReference() {
         byte[] cipher = AriaModes.processOfb(KEY, IV, PLAINTEXT, 8);
         assertArrayEquals(CT_OFB8, cipher);
         byte[] plain = AriaModes.processOfb(KEY, IV, cipher, 8);
@@ -191,8 +191,8 @@ public class AriaModeVectorsTest {
     }
 
     @Test
-    @DisplayName("CTR vector")
-    void ctrVector() {
+    @DisplayName("CTR 모드 테스트 벡터와 결과가 동일해야 한다")
+    void ctrVectorShouldMatchReference() {
         byte[] cipher = AriaModes.processCtr(KEY, IV, PLAINTEXT);
         assertArrayEquals(CT_CTR, cipher);
         byte[] plain = AriaModes.processCtr(KEY, IV, cipher);

--- a/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaModesTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/aria/mode/AriaModesTest.java
@@ -15,8 +15,8 @@ class AriaModesTest {
     private static final byte[] AAD = "header".getBytes();
 
     @Test
-    @DisplayName("CTR mode round-trip")
-    void ctrRoundTrip() {
+    @DisplayName("CTR 모드에서 암복호화 시 원문이 동일하게 복원되어야 한다")
+    void ctrModeShouldRoundTrip() {
         byte[] data = "hello aria ctr".getBytes();
         byte[] enc = AriaModes.processCtr(KEY, IV, data);
         byte[] dec = AriaModes.processCtr(KEY, IV, enc);
@@ -24,8 +24,8 @@ class AriaModesTest {
     }
 
     @Test
-    @DisplayName("CFB mode round-trip")
-    void cfbRoundTrip() {
+    @DisplayName("CFB 모드에서 암복호화 시 원문이 동일하게 복원되어야 한다")
+    void cfbModeShouldRoundTrip() {
         byte[] data = "hello aria cfb".getBytes();
         byte[] enc = AriaModes.encryptCfb(KEY, IV, data);
         byte[] dec = AriaModes.decryptCfb(KEY, IV, enc);
@@ -33,8 +33,8 @@ class AriaModesTest {
     }
 
     @Test
-    @DisplayName("OFB mode round-trip")
-    void ofbRoundTrip() {
+    @DisplayName("OFB 모드에서 암복호화 시 원문이 동일하게 복원되어야 한다")
+    void ofbModeShouldRoundTrip() {
         byte[] data = "hello aria ofb".getBytes();
         byte[] enc = AriaModes.processOfb(KEY, IV, data);
         byte[] dec = AriaModes.processOfb(KEY, IV, enc);
@@ -42,8 +42,8 @@ class AriaModesTest {
     }
 
     @Test
-    @DisplayName("GCM mode round-trip")
-    void gcmRoundTrip() throws InvalidCipherTextException {
+    @DisplayName("GCM 모드 암복호화를 수행하여 태그와 함께 원문이 복원되는지 검증")
+    void gcmModeShouldRoundTrip() throws InvalidCipherTextException {
         byte[] data = "gcm test data".getBytes();
         var res = AriaModes.encryptGcm(KEY, IV, AAD, data, 128);
         byte[] plain = AriaModes.decryptGcm(KEY, IV, AAD, res.ciphertext, res.tag);
@@ -51,8 +51,8 @@ class AriaModesTest {
     }
 
     @Test
-    @DisplayName("CCM mode round-trip")
-    void ccmRoundTrip() throws InvalidCipherTextException {
+    @DisplayName("CCM 모드 암복호화를 수행하여 태그와 함께 원문이 복원되는지 검증")
+    void ccmModeShouldRoundTrip() throws InvalidCipherTextException {
         byte[] data = "ccm test data".getBytes();
         var res = AriaModes.encryptCcm(KEY, IV, AAD, data, 128);
         byte[] plain = AriaModes.decryptCcm(KEY, IV, AAD, res.ciphertext, res.tag);
@@ -60,8 +60,8 @@ class AriaModesTest {
     }
 
     @Test
-    @DisplayName("CMAC computation")
-    void cmacComputation() {
+    @DisplayName("같은 입력에 대한 CMAC 계산 결과가 항상 동일해야 한다")
+    void cmacShouldBeDeterministic() {
         byte[] data = "message".getBytes();
         byte[] mac1 = AriaModes.cmac(KEY, data);
         byte[] mac2 = AriaModes.cmac(KEY, data);

--- a/lib/src/test/java/me/totoku103/crypto/kisa/sha3/Sha3Test.java
+++ b/lib/src/test/java/me/totoku103/crypto/kisa/sha3/Sha3Test.java
@@ -19,8 +19,8 @@ public class Sha3Test {
     }
 
     @Test
-    @DisplayName("SHA3-256 벡터 테스트")
-    public void testSha3256Vector() {
+    @DisplayName("공식 테스트 벡터를 사용한 SHA3-256 해시 검증")
+    public void shouldMatchSha3256TestVector() {
         final Sha3 hasher = new Sha3();
         final byte[] input = "abc".getBytes(StandardCharsets.UTF_8);
         final byte[] out = new byte[32];
@@ -31,8 +31,8 @@ public class Sha3Test {
     }
 
     @Test
-    @DisplayName("한글 입력 SHA3-256")
-    public void testKoreanVector256() {
+    @DisplayName("한글 문자열을 SHA3-256으로 해싱하여 예상 값과 일치하는지 확인")
+    public void shouldHashKoreanTextSha3256() {
         final Sha3 hasher = new Sha3();
         final byte[] input = "안녕하세요".getBytes(StandardCharsets.UTF_8);
         final byte[] out = new byte[32];


### PR DESCRIPTION
## Summary
- expand Korean `@DisplayName` descriptions for clarity
- rename test methods to clearer names

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_684fb59dcfc8832dadc95bfdd2a5f545