### PR TITLE
Add Java HMAC-SHA256

### DIFF
--- a/lib/src/main/java/me/totoku103/crypto/java/hmac/HmacSha256.java
+++ b/lib/src/main/java/me/totoku103/crypto/java/hmac/HmacSha256.java
@@ -1,0 +1,83 @@
+package me.totoku103.crypto.java.hmac;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * HMAC using SHA-256 via JDK {@link javax.crypto.Mac}.
+ */
+public class HmacSha256 {
+    private static final String ALGORITHM_NAME = "HmacSHA256";
+    private static final int OK = 0;
+    private static final int PARAMETER_ERROR = 1;
+
+    /**
+     * Check whether HmacSHA256 algorithm is available in this JDK.
+     */
+    public static boolean isHmacSha256Available() {
+        try {
+            Mac.getInstance(ALGORITHM_NAME);
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Calculate HMAC-SHA256 of the input using the given key and store
+     * the result in the output buffer.
+     *
+     * @param output result buffer
+     * @param outLen expected output length (32)
+     * @param key    secret key
+     * @param keyLen key length
+     * @param input  input data
+     * @param inLen  input length
+     * @return 0 if successful
+     */
+    public int hmacSha256(final byte[] output, final int outLen,
+                          final byte[] key, final int keyLen,
+                          final byte[] input, final int inLen) {
+        try {
+            final Mac mac = Mac.getInstance(ALGORITHM_NAME);
+            final SecretKeySpec keySpec = new SecretKeySpec(key, 0, keyLen, ALGORITHM_NAME);
+            mac.init(keySpec);
+            mac.update(input, 0, inLen);
+            final byte[] result = mac.doFinal();
+            if (result.length != outLen) {
+                return PARAMETER_ERROR;
+            }
+            System.arraycopy(result, 0, output, 0, outLen);
+            return OK;
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            return PARAMETER_ERROR;
+        }
+    }
+
+    /**
+     * Return a new array containing the HMAC-SHA256 value of the input.
+     */
+    public byte[] toHmac(final byte[] key, final byte[] input) {
+        try {
+            final Mac mac = Mac.getInstance(ALGORITHM_NAME);
+            mac.init(new SecretKeySpec(key, ALGORITHM_NAME));
+            return mac.doFinal(input);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalArgumentException("Unsupported algorithm or invalid key", e);
+        }
+    }
+
+    /**
+     * Return the HMAC as a lowercase hex string.
+     */
+    public String encrypt(final byte[] key, final byte[] input) {
+        final byte[] hmac = toHmac(key, input);
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : hmac) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+}

--- a/lib/src/test/java/me/totoku103/crypto/java/hmac/HmacSha256Test.java
+++ b/lib/src/test/java/me/totoku103/crypto/java/hmac/HmacSha256Test.java
@@ -1,0 +1,88 @@
+package me.totoku103.crypto.java.hmac;
+
+import me.totoku103.crypto.utils.HexConverter;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HmacSha256Test {
+
+    private HmacSha256 hmac;
+
+    @BeforeEach
+    void setUp() {
+        this.hmac = new HmacSha256();
+    }
+
+    @Test
+    @DisplayName("JDK에서 HmacSHA256 지원 여부 확인")
+    void isHmacSha256Available() {
+        assertTrue(HmacSha256.isHmacSha256Available());
+    }
+
+    @Test
+    @DisplayName("RFC 4231 테스트 벡터 #1 검증")
+    void testVector1() {
+        Assumptions.assumeTrue(HmacSha256.isHmacSha256Available());
+        byte[] key = new byte[20];
+        java.util.Arrays.fill(key, (byte) 0x0b);
+        byte[] data = "Hi There".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        byte[] expected = HexConverter.toBytes("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+        byte[] out = new byte[32];
+
+        int rc = hmac.hmacSha256(out, out.length, key, key.length, data, data.length);
+        assertEquals(0, rc);
+        assertArrayEquals(expected, out);
+    }
+
+    @Test
+    @DisplayName("RFC 4231 테스트 벡터 #2 검증")
+    void testVector2() {
+        Assumptions.assumeTrue(HmacSha256.isHmacSha256Available());
+        byte[] key = "Jefe".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        byte[] data = "what do ya want for nothing?".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        byte[] expected = HexConverter.toBytes("5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+        byte[] out = new byte[32];
+
+        int rc = hmac.hmacSha256(out, out.length, key, key.length, data, data.length);
+        assertEquals(0, rc);
+        assertArrayEquals(expected, out);
+    }
+
+    @Test
+    @DisplayName("RFC 4231 테스트 벡터 #3 검증")
+    void testVector3() {
+        Assumptions.assumeTrue(HmacSha256.isHmacSha256Available());
+        byte[] key = new byte[20];
+        java.util.Arrays.fill(key, (byte) 0xaa);
+        byte[] data = new byte[50];
+        java.util.Arrays.fill(data, (byte) 0xdd);
+        byte[] expected = HexConverter.toBytes("773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe");
+        byte[] out = new byte[32];
+
+        int rc = hmac.hmacSha256(out, out.length, key, key.length, data, data.length);
+        assertEquals(0, rc);
+        assertArrayEquals(expected, out);
+    }
+
+    @Test
+    @DisplayName("RFC 4231 테스트 벡터 #4 검증")
+    void testVector4() {
+        Assumptions.assumeTrue(HmacSha256.isHmacSha256Available());
+        byte[] key = new byte[25];
+        for (int i = 0; i < key.length; i++) {
+            key[i] = (byte) (i + 1);
+        }
+        byte[] data = new byte[50];
+        java.util.Arrays.fill(data, (byte) 0xcd);
+        byte[] expected = HexConverter.toBytes("82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b");
+        byte[] out = new byte[32];
+
+        int rc = hmac.hmacSha256(out, out.length, key, key.length, data, data.length);
+        assertEquals(0, rc);
+        assertArrayEquals(expected, out);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `HmacSha256` under `me.totoku103.crypto.java.hmac`
- add JUnit tests with RFC 4231 test vectors

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':lib:test' due to missing JDK 8)*

------
https://chatgpt.com/codex/tasks/task_b_6881e75d8760832dad2d716fd496fc2d