### PR TITLE
chore: 배포 버전 1.0.4로 업그레이드

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -47,7 +47,7 @@ tasks.named<Test>("test") {
 
 tasks.jar {
     archiveBaseName.set("crypto")
-    archiveVersion.set("1.0.3")
+    archiveVersion.set("1.0.4")
 }
 
 publishing {
@@ -55,7 +55,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "me.totoku103"
             artifactId = "crypto"
-            version = "1.0.3"
+            version = "1.0.4"
 
             from(components["java"])
         }
@@ -84,7 +84,7 @@ tasks.register("publishToGitHub") {
 
     val injected = project.objects.newInstance<InjectedExecOps>()
     val repoDir = file("/Users/totoku103/Project-Private/totoku103-maven-repository/releases")
-    val version = "1.0.3"
+    val version = "1.0.4"
 
     doLast {
         injected.execOps.exec {


### PR DESCRIPTION
## 개요
배포 버전을 1.0.3 → 1.0.4로 올린다.

## 배경
1.0.3은 `mvn install:install-file -DgeneratePom=true`로 배포되어 pom에 런타임 의존성(BouncyCastle 등)이 누락됐다. 그 결과 소비 측에서 `NoClassDefFoundError: org/bouncycastle/.../OpenBSDBCrypt`가 발생했다. 의존성이 포함된 pom으로 새로 배포하기 위해 1.0.4로 버전을 올린다.

## 변경 내용
- `lib/build.gradle.kts`의 archiveVersion / publication version / publishToGitHub version을 1.0.4로 갱신

## 배포 시 주의
- 반드시 **Gradle publish**(`publishMavenPublicationToLocalRepository`)로 배포하여 pom에 `bcprov-jdk18on:1.81`(runtime) 등 의존성이 포함되도록 한다. `install:install-file -DgeneratePom=true`는 빈 pom을 만들므로 사용하지 않는다.