### PR TITLE
feat: Argon2id 비밀번호 인코더 추가

### DIFF
--- a/docs/password-encryption-evidence.md
+++ b/docs/password-encryption-evidence.md
@@ -1,0 +1,147 @@
+# 비밀번호 DB 암호화 저장 기준 충족 증적자료
+
+## 1. 검토 기준
+
+> 비밀번호 DB 암호화 저장 기준: **단방향 HASH 알고리즘 + salt 적용**
+> (단, HASH 알고리즘은 **256비트 이상**이어야 하며, salt는 **16bytes 이상**, **사용자마다 다르게 랜덤 생성** 필요)
+
+## 2. 적용 알고리즘
+
+| 항목 | 내용 |
+|------|------|
+| 알고리즘 | **Argon2id** (메모리-하드 단방향 KDF) |
+| 구현 라이브러리 | BouncyCastle `bcprov-jdk18on` 1.81 (`Argon2BytesGenerator`) |
+| 표준 | RFC 9106 (Argon2), [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) 1순위 권장 알고리즘 |
+| 저장 포맷 | 표준 PHC 문자열 (파라미터·salt 내장, self-contained) |
+| 구현 클래스 | `me.totoku103.crypto.password.Argon2idPasswordEncoder` |
+
+### 2.1 기본 파라미터 (OWASP 권장 옵션 A)
+
+| 파라미터 | 값 | 비고 |
+|----------|-----|------|
+| 메모리 비용 (m) | 47104 KiB = **46 MiB** | OWASP 권장 옵션 A |
+| 반복 횟수 (t) | **1** | 46MiB와 짝을 이루는 권장값 |
+| 병렬도 (p) | **1** | |
+| salt 길이 | **16 bytes** | `SecureRandom` 사용자별 랜덤 |
+| 해시 출력 길이 | **32 bytes = 256 bits** | |
+
+## 3. 기준별 충족 매핑
+
+| 검토 기준 | 충족 | 구현 근거 | 검증 테스트 |
+|-----------|:----:|-----------|-------------|
+| 단방향 HASH 알고리즘 | ✅ | Argon2id는 복호화 불가능한 단방향 KDF. `encode()` 결과에 원문이 포함되지 않음 | `encode_resultDiffersFromRawPassword` |
+| **HASH 256비트 이상** | ✅ | 해시 출력 `HASH_LENGTH = 32` bytes = **256 bits** | `encode_producesSalt16BytesAndHash32Bytes` |
+| salt **16bytes 이상** | ✅ | `SALT_LENGTH = 16` bytes | `encode_producesSalt16BytesAndHash32Bytes` |
+| salt **사용자마다 랜덤** | ✅ | `SecureRandom.nextBytes(salt)`를 `encode()` 호출마다 실행 | `encode_usesRandomSaltPerCall` |
+
+> **참고 — bcrypt 대비 개선점:** 기존 bcrypt는 해시 출력이 184비트로 "256비트 이상" 기준을 문자 그대로 충족하지 못했으나, Argon2id는 해시 출력 길이를 32바이트(256비트)로 지정하여 기준을 **명시적으로 충족**한다.
+
+## 4. 저장 포맷 (PHC 문자열)
+
+```
+$argon2id$v=19$m=47104,t=1,p=1$<base64(salt)>$<base64(hash)>
+```
+
+- `v=19` : Argon2 버전 1.3
+- `m`, `t`, `p` : 메모리·반복·병렬 파라미터
+- salt와 hash는 패딩 없는 Base64로 인코딩
+- 파라미터와 salt가 문자열에 모두 포함되어 **별도 컬럼 없이 검증 가능**
+
+예시 구조(값은 매 호출마다 랜덤 salt로 달라짐):
+
+```
+$argon2id$v=19$m=47104,t=1,p=1$<22자 base64 salt>$<43자 base64 hash>
+```
+
+## 5. 보안 설계 세부
+
+| 항목 | 설명 |
+|------|------|
+| 사용자별 랜덤 salt | `SecureRandom`(CSPRNG)으로 매 인코딩마다 16바이트 생성 → rainbow table 무력화 |
+| 메모리-하드 | 46MiB 메모리를 요구해 GPU·ASIC 대량 병렬 공격 비용을 크게 증가 |
+| 상수 시간 비교 | 검증 시 `MessageDigest.isEqual`로 타이밍 공격 방지 |
+| 레거시 버전 호환 | 검증(`matches`)은 저장된 해시의 버전(v=16/v=19)으로 재계산하여 과거 해시도 정상 인증 |
+| 자원 고갈 방지 | 신뢰할 수 없는 입력의 과도한 메모리 파라미터(m > 1 GiB)는 OOM 없이 불일치 처리 |
+
+## 6. 검증 결과
+
+JUnit 5 기반 단위·경계·보안 명세 테스트 **22개 전부 통과**.
+
+| 검증 항목 | 테스트 |
+|-----------|--------|
+| 표준 PHC 포맷 생성 | `encode_returnsStandardPhcFormat` |
+| salt 16byte / hash 32byte(256bit) | `encode_producesSalt16BytesAndHash32Bytes` |
+| 사용자별 랜덤 salt | `encode_usesRandomSaltPerCall` |
+| 정상 비밀번호 검증 성공 | `matches_returnsTrueForCorrectPassword` |
+| 틀린 비밀번호 검증 실패 | `matches_returnsFalseForWrongPassword` |
+| 유니코드 비밀번호 | `matches_supportsUnicodePassword` |
+| 단방향성(원문 미포함) | `encode_resultDiffersFromRawPassword` |
+| 기본 파라미터(OWASP 옵션 A) | `defaultConstructor_usesOwaspRecommendedParameters` |
+| 레거시 v=16 해시 검증 | `matches_verifiesLegacyVersion16Hash` |
+| 자원 고갈 방지 | `matches_returnsFalseForExcessiveMemoryWithoutOom` |
+
+### 재현 방법
+
+```bash
+./gradlew :lib:test --tests "me.totoku103.crypto.password.Argon2idPasswordEncoderTest"
+```
+
+## 7. 실행 예시 (실제 해시 값)
+
+원문 `P@ssw0rd!` 를 기본 파라미터로 두 번 인코딩한 실제 출력이다.
+
+```
+원문 비밀번호 : P@ssw0rd!
+해시 결과 #1  : $argon2id$v=19$m=47104,t=1,p=1$y3HEkn9GhdJ2yxqMVjv86Q$fwAM/kO2m2HEWfkzR2cjfpM9r8wS8pdFTgNCyu5Qv6M
+해시 결과 #2  : $argon2id$v=19$m=47104,t=1,p=1$NjeCI76Pv4fYnuHVlEW1lg$C6wYEuT038eg2VQhv051j0TjIop5wwD2ZBjkcfZTNOY
+```
+
+### 7.1 PHC 포맷 분해 — salt 위치
+
+```
+$argon2id$v=19$m=47104,t=1,p=1$ y3HEkn9GhdJ2yxqMVjv86Q $ fwAM/kO2m2HEWfkzR2cjfpM9r8wS8pdFTgNCyu5Qv6M
+ └ 알고리즘  └버전 └ 파라미터       └─ salt (base64) ─┘   └──────── hash (base64) ────────┘
+```
+
+| 구획 | 값 | 의미 |
+|------|-----|------|
+| 알고리즘 | `argon2id` | 단방향 해시 |
+| 버전 | `v=19` | Argon2 1.3 |
+| 파라미터 | `m=47104,t=1,p=1` | 메모리 46MiB, 반복 1, 병렬 1 |
+| **salt** | `y3HEkn9GhdJ2yxqMVjv86Q` | base64 → 디코딩 시 **16 bytes** |
+| hash | `fwAM/kO2...` | base64 → 디코딩 시 **32 bytes(256 bits)** |
+
+### 7.2 salt 적용 확인 결과
+
+```
+[salt 확인]
+  salt 길이 : 16 bytes (기준: 16 이상)        ✅
+  hash 길이 : 32 bytes = 256 bits (기준: 256 이상)  ✅
+
+[사용자별 랜덤 salt 증명]  ← 같은 비밀번호를 두 번 해시했으나 salt가 다름
+  #1 salt : y3HEkn9GhdJ2yxqMVjv86Q
+  #2 salt : NjeCI76Pv4fYnuHVlEW1lg
+  두 salt가 서로 다른가? true            ✅
+
+[검증]
+  matches(올바른 비밀번호) : true         ✅
+  matches(틀린 비밀번호)   : false        ✅
+```
+
+- **salt 내장 확인:** 해시 문자열을 `$`로 분리했을 때 5번째 토큰이 salt이며, base64 디코딩 시 정확히 16바이트다.
+- **사용자별 랜덤 확인:** 동일 원문을 두 번 인코딩해도 salt와 결과가 완전히 다르다 → `SecureRandom`으로 매번 새 salt 생성.
+
+명령줄에서 salt만 추출하려면:
+
+```bash
+HASH='$argon2id$v=19$m=47104,t=1,p=1$y3HEkn9GhdJ2yxqMVjv86Q$fwAM/kO2m2HEWfkzR2cjfpM9r8wS8pdFTgNCyu5Qv6M'
+echo "$HASH" | cut -d'$' -f5    # → y3HEkn9GhdJ2yxqMVjv86Q (salt, base64)
+```
+
+> 위 해시 값은 시연용 실제 출력이며, salt가 매 호출마다 랜덤 생성되므로 재실행 시 값은 달라진다.
+
+## 8. 결론
+
+Argon2id 기반 비밀번호 저장 구현은 검토 기준의 4개 요건
+(**단방향 HASH / 256비트 이상 / salt 16bytes 이상 / 사용자별 랜덤 salt**)을
+**모두 명시적으로 충족**하며, OWASP 1순위 권장 알고리즘과 권장 파라미터를 적용하였다.

--- a/lib/src/main/java/me/totoku103/crypto/password/Argon2idPasswordEncoder.java
+++ b/lib/src/main/java/me/totoku103/crypto/password/Argon2idPasswordEncoder.java
@@ -1,0 +1,256 @@
+package me.totoku103.crypto.password;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+
+/**
+ * Argon2id 기반 {@link PasswordEncoder} 구현.
+ *
+ * <p>BouncyCastle {@link Argon2BytesGenerator}를 사용하며, 인코딩 시 {@link SecureRandom}으로 16바이트
+ * 랜덤 salt를 생성하고 256비트(32바이트) 해시를 산출한다. 결과는 표준 PHC 문자열 포맷
+ * {@code $argon2id$v=19$m=<memory>,t=<iterations>,p=<parallelism>$<salt>$<hash>} 로, 파라미터와 salt가
+ * 모두 포함(self-contained)되어 별도 컬럼 없이 검증할 수 있다.
+ *
+ * <p><b>비밀번호 DB 암호화 저장 기준 충족:</b>
+ * <ul>
+ *   <li>단방향 HASH: Argon2id(메모리-하드 단방향 KDF)</li>
+ *   <li>HASH 출력 256비트: {@link #HASH_LENGTH}=32바이트</li>
+ *   <li>salt 16바이트 이상: {@link #SALT_LENGTH}=16바이트</li>
+ *   <li>사용자별 랜덤 salt: {@link SecureRandom}으로 encode마다 생성</li>
+ * </ul>
+ *
+ * <p>OWASP 권장 파라미터(메모리 46MiB, 반복 1, 병렬 1 — OWASP 옵션 A)를 기본값으로 사용한다.
+ *
+ * <p><b>검증 시 버전 처리:</b> 인코딩은 항상 최신 Argon2 1.3(v=19)으로 수행하지만, 검증({@link #matches})은
+ * 저장된 해시에 기록된 버전(1.0=v=16 또는 1.3=v=19)으로 재계산한다. 따라서 과거 버전으로 생성된 해시도
+ * 올바른 비밀번호면 검증에 성공한다. 단, 이 클래스는 해시 생성·검증만 담당하며 구버전 해시를 최신 버전으로
+ * 재해시(마이그레이션)하지는 않는다.
+ */
+public class Argon2idPasswordEncoder implements PasswordEncoder {
+
+  /** salt 길이(바이트). KT 기준(≥16byte)을 충족한다. */
+  private static final int SALT_LENGTH = 16;
+
+  /** 해시 출력 길이(바이트). 32바이트=256비트로 KT 기준(≥256bit)을 충족한다. */
+  private static final int HASH_LENGTH = 32;
+
+  /** Argon2 1.0 버전 식별자(0x10=16). 과거 생성된 해시 검증을 위해 허용한다. */
+  private static final int ARGON2_VERSION_10 = Argon2Parameters.ARGON2_VERSION_10;
+
+  /** Argon2 1.3 버전 식별자(0x13=19). PHC 문자열의 {@code v=19}에 해당한다. */
+  private static final int ARGON2_VERSION_13 = Argon2Parameters.ARGON2_VERSION_13;
+
+  /** 신규 인코딩에 사용하는 버전. 항상 최신(1.3=v=19). */
+  private static final int GENERATE_VERSION = ARGON2_VERSION_13;
+
+  /**
+   * 검증 시 신뢰할 수 없는 PHC 문자열의 과도한 메모리 파라미터로 인한 자원 고갈(OOM)을 막기 위한 상한(KiB).
+   * 1 GiB. 비밀번호 해시에 필요한 메모리는 통상 수십 MiB 수준이므로 정상 값은 이 한도를 넘지 않는다.
+   */
+  private static final int MAX_MEMORY_KB = 1 << 20;
+
+  /** OWASP 권장 기본 메모리 비용(KiB). 47104 KiB = 46 MiB (OWASP 옵션 A). */
+  public static final int DEFAULT_MEMORY_KB = 47104;
+
+  /** OWASP 권장 기본 반복 횟수(time cost). 메모리 46MiB와 짝을 이루는 t=1. */
+  public static final int DEFAULT_ITERATIONS = 1;
+
+  /** OWASP 권장 기본 병렬도(lane 수). */
+  public static final int DEFAULT_PARALLELISM = 1;
+
+  /**
+   * {@code $argon2id$v=<n>$m=<n>,t=<n>,p=<n>$<saltB64>$<hashB64>} 형태의 표준 PHC 포맷.
+   * salt/hash는 패딩 없는 base64.
+   */
+  private static final Pattern PHC_PATTERN =
+      Pattern.compile(
+          "^\\$argon2id\\$v=(\\d+)\\$m=(\\d+),t=(\\d+),p=(\\d+)\\$([A-Za-z0-9+/]+)\\$([A-Za-z0-9+/]+)$");
+
+  private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
+  private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+
+  private final int memoryKb;
+  private final int iterations;
+  private final int parallelism;
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  /** OWASP 권장 기본 파라미터로 생성한다. */
+  public Argon2idPasswordEncoder() {
+    this(DEFAULT_MEMORY_KB, DEFAULT_ITERATIONS, DEFAULT_PARALLELISM);
+  }
+
+  /**
+   * 지정한 파라미터로 생성한다.
+   *
+   * @param memoryKb 메모리 비용(KiB), 양수
+   * @param iterations 반복 횟수(time cost), 양수
+   * @param parallelism 병렬도(lane 수), 양수
+   * @throws IllegalArgumentException 파라미터가 1 미만인 경우
+   */
+  public Argon2idPasswordEncoder(int memoryKb, int iterations, int parallelism) {
+    if (memoryKb < 1) {
+      throw new IllegalArgumentException("memoryKb must be >= 1: " + memoryKb);
+    }
+    if (iterations < 1) {
+      throw new IllegalArgumentException("iterations must be >= 1: " + iterations);
+    }
+    if (parallelism < 1) {
+      throw new IllegalArgumentException("parallelism must be >= 1: " + parallelism);
+    }
+    this.memoryKb = memoryKb;
+    this.iterations = iterations;
+    this.parallelism = parallelism;
+  }
+
+  @Override
+  public String encode(CharSequence rawPassword) {
+    if (rawPassword == null) {
+      throw new IllegalArgumentException("rawPassword must not be null");
+    }
+    byte[] salt = new byte[SALT_LENGTH];
+    secureRandom.nextBytes(salt);
+    byte[] hash =
+        hash(rawPassword, salt, GENERATE_VERSION, memoryKb, iterations, parallelism, HASH_LENGTH);
+    return format(salt, hash, GENERATE_VERSION, memoryKb, iterations, parallelism);
+  }
+
+  @Override
+  public boolean matches(CharSequence rawPassword, String encodedPassword) {
+    if (rawPassword == null) {
+      return false;
+    }
+    Matcher matcher = matchPhc(encodedPassword);
+    if (matcher == null) {
+      return false;
+    }
+    try {
+      int version = Integer.parseInt(matcher.group(1));
+      // 알려진 Argon2 버전(1.0/1.3)만 검증 대상. 저장된 버전 그대로 재계산해야 일치한다.
+      if (version != ARGON2_VERSION_10 && version != ARGON2_VERSION_13) {
+        return false;
+      }
+      int storedMemory = Integer.parseInt(matcher.group(2));
+      // 신뢰할 수 없는 입력의 거대 메모리 값으로 인한 OOM 방지
+      if (storedMemory > MAX_MEMORY_KB) {
+        return false;
+      }
+      int storedIterations = Integer.parseInt(matcher.group(3));
+      int storedParallelism = Integer.parseInt(matcher.group(4));
+      byte[] storedSalt = BASE64_DECODER.decode(matcher.group(5));
+      byte[] storedHash = BASE64_DECODER.decode(matcher.group(6));
+
+      byte[] computed =
+          hash(
+              rawPassword,
+              storedSalt,
+              version,
+              storedMemory,
+              storedIterations,
+              storedParallelism,
+              storedHash.length);
+      // 상수 시간 비교로 타이밍 공격 방지
+      return MessageDigest.isEqual(storedHash, computed);
+    } catch (RuntimeException e) {
+      // 패턴은 통과해도 base64 디코딩·파라미터 파싱에 실패하면 불일치로 간주
+      return false;
+    }
+  }
+
+  @Override
+  public boolean upgradeNeeded(String encodedPassword) {
+    Matcher matcher = matchPhc(encodedPassword);
+    if (matcher == null) {
+      // 레거시·null·형식 불일치(bcrypt, ARIA 등)는 모두 재해시 대상
+      return true;
+    }
+    int storedMemory = Integer.parseInt(matcher.group(2));
+    int storedIterations = Integer.parseInt(matcher.group(3));
+    int storedParallelism = Integer.parseInt(matcher.group(4));
+    // 저장된 비용 파라미터 중 하나라도 현재 정책보다 낮으면 재해시 필요
+    return storedMemory < memoryKb
+        || storedIterations < iterations
+        || storedParallelism < parallelism;
+  }
+
+  /**
+   * 문자열이 표준 Argon2id PHC 포맷인지 확인한다.
+   *
+   * @param value 검사할 문자열
+   * @return Argon2id 포맷이면 true
+   */
+  public static boolean isArgon2idHash(String value) {
+    return matchPhc(value) != null;
+  }
+
+  /** 설정된 메모리 비용(KiB)을 반환한다. */
+  public int getMemoryKb() {
+    return memoryKb;
+  }
+
+  /** 설정된 반복 횟수를 반환한다. */
+  public int getIterations() {
+    return iterations;
+  }
+
+  /** 설정된 병렬도를 반환한다. */
+  public int getParallelism() {
+    return parallelism;
+  }
+
+  /** 매칭에 성공하면 {@link Matcher}를, 아니면 null을 반환한다. */
+  private static Matcher matchPhc(String value) {
+    if (value == null) {
+      return null;
+    }
+    Matcher matcher = PHC_PATTERN.matcher(value);
+    return matcher.matches() ? matcher : null;
+  }
+
+  private static byte[] hash(
+      CharSequence rawPassword,
+      byte[] salt,
+      int version,
+      int memoryKb,
+      int iterations,
+      int parallelism,
+      int outputLength) {
+    Argon2Parameters params =
+        new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+            .withVersion(version)
+            .withMemoryAsKB(memoryKb)
+            .withIterations(iterations)
+            .withParallelism(parallelism)
+            .withSalt(salt)
+            .build();
+
+    Argon2BytesGenerator generator = new Argon2BytesGenerator();
+    generator.init(params);
+
+    byte[] output = new byte[outputLength];
+    byte[] passwordBytes = rawPassword.toString().getBytes(StandardCharsets.UTF_8);
+    generator.generateBytes(passwordBytes, output);
+    return output;
+  }
+
+  private static String format(
+      byte[] salt, byte[] hash, int version, int memoryKb, int iterations, int parallelism) {
+    return "$argon2id$v="
+        + version
+        + "$m="
+        + memoryKb
+        + ",t="
+        + iterations
+        + ",p="
+        + parallelism
+        + "$"
+        + BASE64_ENCODER.encodeToString(salt)
+        + "$"
+        + BASE64_ENCODER.encodeToString(hash);
+  }
+}

--- a/lib/src/test/java/me/totoku103/crypto/password/Argon2idPasswordEncoderTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/password/Argon2idPasswordEncoderTest.java
@@ -1,0 +1,255 @@
+package me.totoku103.crypto.password;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Argon2idPasswordEncoder 단위 테스트.
+ *
+ * <p>대부분의 테스트는 빠른 실행을 위해 작은 비용 파라미터(memory 256KiB, t=1, p=1)를 사용한다.
+ * 기본 생성자(OWASP 권장 파라미터) 검증은 별도 테스트에서 다룬다.
+ */
+class Argon2idPasswordEncoderTest {
+
+  /** 빠른 테스트용 저비용 인코더. */
+  private final Argon2idPasswordEncoder encoder = new Argon2idPasswordEncoder(256, 1, 1);
+
+  @Test
+  void encode_returnsStandardPhcFormat() {
+    String hash = encoder.encode("P@ssw0rd!");
+
+    // $argon2id$v=19$m=256,t=1,p=1$<saltB64>$<hashB64>
+    assertTrue(
+        hash.matches("^\\$argon2id\\$v=19\\$m=256,t=1,p=1\\$[A-Za-z0-9+/]+\\$[A-Za-z0-9+/]+$"),
+        "표준 Argon2id PHC 포맷이어야 함: " + hash);
+    assertTrue(Argon2idPasswordEncoder.isArgon2idHash(hash));
+  }
+
+  @Test
+  void encode_producesSalt16BytesAndHash32Bytes() {
+    String hash = encoder.encode("length-check");
+
+    String[] parts = hash.split("\\$");
+    // ["", "argon2id", "v=19", "m=256,t=1,p=1", saltB64, hashB64]
+    assertEquals(6, parts.length, "PHC는 6개 구획으로 분리되어야 함: " + hash);
+
+    byte[] salt = Base64.getDecoder().decode(parts[4]);
+    byte[] hashBytes = Base64.getDecoder().decode(parts[5]);
+
+    assertEquals(16, salt.length, "salt는 16바이트(≥16byte 기준)여야 함");
+    assertEquals(32, hashBytes.length, "hash는 32바이트(256비트 기준)여야 함");
+  }
+
+  @Test
+  void encode_usesRandomSaltPerCall() {
+    String h1 = encoder.encode("samePassword");
+    String h2 = encoder.encode("samePassword");
+
+    // 같은 원문이라도 salt가 매번 달라 결과가 달라야 함
+    assertNotEquals(h1, h2);
+  }
+
+  @Test
+  void matches_returnsTrueForCorrectPassword() {
+    String hash = encoder.encode("correct-horse");
+    assertTrue(encoder.matches("correct-horse", hash));
+  }
+
+  @Test
+  void matches_returnsFalseForWrongPassword() {
+    String hash = encoder.encode("correct-horse");
+    assertFalse(encoder.matches("wrong-horse", hash));
+  }
+
+  @Test
+  void matches_supportsUnicodePassword() {
+    String raw = "한글비밀번호_123!@#";
+    String hash = encoder.encode(raw);
+    assertTrue(encoder.matches(raw, hash));
+    assertFalse(encoder.matches("한글비밀번호_124!@#", hash));
+  }
+
+  @Test
+  void matches_verifiesHashEncodedWithDifferentParameters() {
+    // 저장 시점의 파라미터(PHC에 내장)로 재계산해야 하므로,
+    // 현재 인코더 파라미터와 다른 파라미터로 만든 해시도 검증 가능해야 한다.
+    Argon2idPasswordEncoder stored = new Argon2idPasswordEncoder(512, 2, 1);
+    String hash = stored.encode("cross-param");
+
+    Argon2idPasswordEncoder current = new Argon2idPasswordEncoder(256, 1, 1);
+    assertTrue(current.matches("cross-param", hash), "PHC 내장 파라미터로 검증되어야 함");
+  }
+
+  @Test
+  void matches_returnsFalseForNullOrMalformedHash() {
+    assertFalse(encoder.matches("pw", null));
+    assertFalse(encoder.matches("pw", ""));
+    assertFalse(encoder.matches("pw", "not-an-argon2-hash"));
+    // bcrypt 해시 형태도 형식 불일치로 false
+    assertFalse(encoder.matches("pw", "$2y$12$LrmaIX5zpmBdoMFtRwu1KOdiTNFnR6NKfVPGMgfF3Yx5VTmqBYWiO"));
+    // 레거시 ARIA 암호문(대문자 16진수) 형태도 false
+    assertFalse(encoder.matches("pw", "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"));
+  }
+
+  @Test
+  void matches_returnsFalseForNullRawPassword() {
+    String hash = encoder.encode("pw");
+    assertFalse(encoder.matches(null, hash));
+  }
+
+  @Test
+  void encode_rejectsNullPassword() {
+    assertThrows(IllegalArgumentException.class, () -> encoder.encode(null));
+  }
+
+  @Test
+  void parameters_areConfigurableAndReflectedInHash() {
+    Argon2idPasswordEncoder custom = new Argon2idPasswordEncoder(1024, 3, 2);
+    assertEquals(1024, custom.getMemoryKb());
+    assertEquals(3, custom.getIterations());
+    assertEquals(2, custom.getParallelism());
+
+    String hash = custom.encode("pw");
+    assertTrue(hash.startsWith("$argon2id$v=19$m=1024,t=3,p=2$"), "파라미터가 해시에 반영되어야 함: " + hash);
+  }
+
+  @Test
+  void constructor_rejectsNonPositiveParameters() {
+    assertThrows(IllegalArgumentException.class, () -> new Argon2idPasswordEncoder(0, 1, 1));
+    assertThrows(IllegalArgumentException.class, () -> new Argon2idPasswordEncoder(256, 0, 1));
+    assertThrows(IllegalArgumentException.class, () -> new Argon2idPasswordEncoder(256, 1, 0));
+  }
+
+  @Test
+  void upgradeNeeded_trueForLegacyOrNonArgon2() {
+    // null, 빈 값, bcrypt, 레거시 ARIA 형식 등 argon2id가 아니면 재해시 대상
+    assertTrue(encoder.upgradeNeeded(null));
+    assertTrue(encoder.upgradeNeeded(""));
+    assertTrue(
+        encoder.upgradeNeeded("$2y$12$LrmaIX5zpmBdoMFtRwu1KOdiTNFnR6NKfVPGMgfF3Yx5VTmqBYWiO"));
+    assertTrue(encoder.upgradeNeeded("A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"));
+  }
+
+  @Test
+  void upgradeNeeded_trueWhenStoredParametersAreWeaker() {
+    String weak = new Argon2idPasswordEncoder(256, 1, 1).encode("pw");
+    // 저장된 메모리(256) < 현재 정책(512) → 재해시 필요
+    Argon2idPasswordEncoder strongerMemory = new Argon2idPasswordEncoder(512, 1, 1);
+    assertTrue(strongerMemory.upgradeNeeded(weak));
+
+    // 저장된 반복(1) < 현재 정책(2) → 재해시 필요
+    Argon2idPasswordEncoder strongerIterations = new Argon2idPasswordEncoder(256, 2, 1);
+    assertTrue(strongerIterations.upgradeNeeded(weak));
+  }
+
+  @Test
+  void upgradeNeeded_falseWhenParametersMeetPolicy() {
+    String current = new Argon2idPasswordEncoder(256, 1, 1).encode("pw");
+    Argon2idPasswordEncoder policy = new Argon2idPasswordEncoder(256, 1, 1);
+    assertFalse(policy.upgradeNeeded(current));
+  }
+
+  @Test
+  void upgradeNeeded_falseWhenStoredParametersAreStronger() {
+    String strong = new Argon2idPasswordEncoder(512, 2, 1).encode("pw");
+    Argon2idPasswordEncoder policy = new Argon2idPasswordEncoder(256, 1, 1);
+    // 저장된 파라미터가 정책보다 강하면 재해시 불필요
+    assertFalse(policy.upgradeNeeded(strong));
+  }
+
+  @Test
+  void isArgon2idHash_detectsFormat() {
+    assertTrue(Argon2idPasswordEncoder.isArgon2idHash(encoder.encode("pw")));
+    assertFalse(Argon2idPasswordEncoder.isArgon2idHash(null));
+    assertFalse(Argon2idPasswordEncoder.isArgon2idHash("A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4"));
+    assertFalse(
+        Argon2idPasswordEncoder.isArgon2idHash(
+            "$2y$12$LrmaIX5zpmBdoMFtRwu1KOdiTNFnR6NKfVPGMgfF3Yx5VTmqBYWiO"));
+  }
+
+  @Test
+  void defaultConstructor_usesOwaspRecommendedParameters() {
+    Argon2idPasswordEncoder defaultEncoder = new Argon2idPasswordEncoder();
+    assertEquals(47104, defaultEncoder.getMemoryKb(), "기본 메모리는 47104 KiB(46MiB, OWASP 옵션 A)여야 함");
+    assertEquals(1, defaultEncoder.getIterations(), "기본 반복은 1이어야 함");
+    assertEquals(1, defaultEncoder.getParallelism(), "기본 병렬도는 1이어야 함");
+
+    // 기본 파라미터로도 정상 인코딩·검증 라운드트립이 동작해야 함
+    String hash = defaultEncoder.encode("owasp-default");
+    assertTrue(hash.startsWith("$argon2id$v=19$m=47104,t=1,p=1$"));
+    assertTrue(defaultEncoder.matches("owasp-default", hash));
+  }
+
+  @Test
+  void encode_resultDiffersFromRawPassword() {
+    String raw = "my-secret-password";
+    String hash = encoder.encode(raw);
+    assertNotEquals(raw, hash, "encode 결과는 원문과 같으면 안 됨(단방향성)");
+    assertFalse(hash.contains(raw), "해시 내부에 원문이 평문으로 포함되면 안 됨");
+  }
+
+  @Test
+  void matches_verifiesLegacyVersion16Hash() {
+    // 과거 Argon2 1.0(v=16)으로 생성된 해시도 올바른 비밀번호면 검증에 성공해야 한다.
+    // (인코더는 항상 v=19로 생성하므로 v=16 해시는 BouncyCastle로 직접 만든다.)
+    String legacyHash = encodeWithVersion(Argon2Parameters.ARGON2_VERSION_10, "legacy-pw", 256, 1, 1);
+    assertTrue(legacyHash.startsWith("$argon2id$v=16$"), "v=16 해시여야 함: " + legacyHash);
+
+    assertTrue(encoder.matches("legacy-pw", legacyHash), "v=16 해시도 올바른 비밀번호면 matches=true여야 함");
+    assertFalse(encoder.matches("wrong-pw", legacyHash), "v=16 해시도 틀린 비밀번호면 matches=false여야 함");
+  }
+
+  @Test
+  void matches_returnsFalseForUnknownVersion() {
+    // 알 수 없는 버전(v=99)은 검증 대상이 아니므로 false.
+    String hash = encoder.encode("pw");
+    String tampered = hash.replaceFirst("\\$v=19\\$", "\\$v=99\\$");
+    assertFalse(encoder.matches("pw", tampered), "알 수 없는 버전(v=99)은 false여야 함");
+  }
+
+  @Test
+  void matches_returnsFalseForExcessiveMemoryWithoutOom() {
+    // 신뢰할 수 없는 거대 메모리 파라미터(m=2147483647)는 OOM 없이 false로 처리되어야 한다.
+    String hash = encoder.encode("pw");
+    String tampered = hash.replaceFirst("m=256,", "m=2147483647,");
+    assertFalse(encoder.matches("pw", tampered), "과도한 메모리 파라미터는 OOM 없이 false여야 함");
+  }
+
+  /** 지정한 Argon2 버전으로 PHC 포맷 해시 문자열을 생성한다(테스트 전용 헬퍼). */
+  private static String encodeWithVersion(int version, String raw, int memoryKb, int t, int p) {
+    byte[] salt = new byte[16];
+    new SecureRandom().nextBytes(salt);
+    Argon2Parameters params =
+        new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+            .withVersion(version)
+            .withMemoryAsKB(memoryKb)
+            .withIterations(t)
+            .withParallelism(p)
+            .withSalt(salt)
+            .build();
+    Argon2BytesGenerator generator = new Argon2BytesGenerator();
+    generator.init(params);
+    byte[] out = new byte[32];
+    generator.generateBytes(raw.getBytes(StandardCharsets.UTF_8), out);
+
+    Base64.Encoder b64 = Base64.getEncoder().withoutPadding();
+    return "$argon2id$v="
+        + version
+        + "$m="
+        + memoryKb
+        + ",t="
+        + t
+        + ",p="
+        + p
+        + "$"
+        + b64.encodeToString(salt)
+        + "$"
+        + b64.encodeToString(out);
+  }
+}


### PR DESCRIPTION
## 개요

비밀번호 DB 암호화 저장 기준을 충족하는 **Argon2id 기반 `PasswordEncoder`** 를 추가합니다.

기존 bcrypt는 해시 출력이 184비트라 "HASH 256비트 이상" 기준을 문자 그대로 충족하지 못했습니다. Argon2id는 해시 출력을 32바이트(256비트)로 지정해 기준을 명시적으로 충족합니다.

## 검토 기준 충족

| 기준 | 충족 | 근거 |
|------|:----:|------|
| 단방향 HASH 알고리즘 | ✅ | Argon2id (메모리-하드 단방향 KDF) |
| HASH 256비트 이상 | ✅ | 해시 출력 32 bytes = 256 bits |
| salt 16bytes 이상 | ✅ | salt 16 bytes |
| salt 사용자별 랜덤 | ✅ | `SecureRandom`으로 `encode`마다 생성 |

## 구현 세부

- BouncyCastle `Argon2BytesGenerator` 사용, 표준 PHC 포맷으로 self-contained 저장
  - `$argon2id$v=19$m=47104,t=1,p=1$<salt>$<hash>`
- 기본 파라미터: **OWASP 옵션 A** (메모리 46MiB, 반복 1, 병렬 1)
- `matches`는 저장된 버전(v=16/v=19)으로 검증 → 레거시 Argon2 해시도 정상 인증
- 상수 시간 비교(`MessageDigest.isEqual`)로 타이밍 공격 방지
- 신뢰 불가 입력의 과도한 메모리 파라미터(m > 1 GiB)에 대한 OOM 방지 가드

## 증적자료

검토자 제출용 문서 `docs/password-encryption-evidence.md` 포함 (기준별 충족 매핑, 파라미터, 테스트 목록, 재현 방법).

## 테스트

JUnit 5 단위·경계·버전·보안 명세 테스트 **22개 전부 통과**.

```bash
./gradlew :lib:test --tests "me.totoku103.crypto.password.Argon2idPasswordEncoderTest"
```

- [x] 단위 테스트 (encode/matches/upgradeNeeded)
- [x] 경계: salt 16byte / hash 32byte(256bit), 파라미터 검증
- [x] 버전 호환: 레거시 v=16 해시 검증, 알 수 없는 버전 거부
- [x] 보안: 사용자별 랜덤 salt, 단방향성, OOM 방지
