### PR TITLE
feat: Aes256BlockCipher CBC 모드 추가 및 v1.1.0 릴리즈

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
     `maven-publish`
 }
 
+// 배포 버전. 여기 한 곳만 고치면 jar / publish / GitHub 배포에 모두 반영된다.
+val libraryVersion = "1.1.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.
@@ -47,7 +49,7 @@ tasks.named<Test>("test") {
 
 tasks.jar {
     archiveBaseName.set("crypto")
-    archiveVersion.set("1.1.0")
+    archiveVersion.set(libraryVersion)
 }
 
 publishing {
@@ -55,7 +57,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "me.totoku103"
             artifactId = "crypto"
-            version = "1.1.0"
+            version = libraryVersion
 
             from(components["java"])
         }
@@ -84,7 +86,7 @@ tasks.register("publishToGitHub") {
 
     val injected = project.objects.newInstance<InjectedExecOps>()
     val repoDir = file("/Users/totoku103/Project-Private/totoku103-maven-repository/releases")
-    val version = "1.1.0"
+    val version = libraryVersion
 
     doLast {
         injected.execOps.exec {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -47,7 +47,7 @@ tasks.named<Test>("test") {
 
 tasks.jar {
     archiveBaseName.set("crypto")
-    archiveVersion.set("1.0.5")
+    archiveVersion.set("1.1.0")
 }
 
 publishing {
@@ -55,7 +55,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "me.totoku103"
             artifactId = "crypto"
-            version = "1.0.5"
+            version = "1.1.0"
 
             from(components["java"])
         }
@@ -84,7 +84,7 @@ tasks.register("publishToGitHub") {
 
     val injected = project.objects.newInstance<InjectedExecOps>()
     val repoDir = file("/Users/totoku103/Project-Private/totoku103-maven-repository/releases")
-    val version = "1.0.5"
+    val version = "1.1.0"
 
     doLast {
         injected.execOps.exec {

--- a/lib/src/main/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipher.java
+++ b/lib/src/main/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipher.java
@@ -2,19 +2,55 @@ package me.totoku103.crypto.algorithms.cipher;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
 import me.totoku103.crypto.core.BlockCipher;
 import me.totoku103.crypto.core.utils.ByteUtils;
+import me.totoku103.crypto.enums.CipherMode;
 
-/** AES-256 블록 암호화 알고리즘 구현 */
+/**
+ * AES-256 블록 암호화 구현. ECB/CBC 모드를 지원하며 모드는 생성자로 정한다(기본값 ECB).
+ *
+ * <p>CBC일 때 IV를 다루는 방법은 두 가지다.
+ *
+ * <ul>
+ *   <li>2-arg encrypt/decrypt: IV를 랜덤으로 만들어 암호문 앞 16바이트에 붙여 준다. 복호화할 때 다시 떼어 쓰므로
+ *       호출부에서 IV를 따로 신경 쓸 필요가 없다.
+ *   <li>3-arg encrypt/decrypt: IV를 직접 넘긴다. 암호문에는 IV가 안 붙으니 복호화할 때 같은 IV를 넘겨야 한다.
+ *       KAT 벡터 검증이나 외부 시스템과 포맷을 맞춰야 할 때 쓴다.
+ * </ul>
+ *
+ * <p>ECB에는 IV가 없으므로 3-arg를 호출하면 {@link UnsupportedOperationException}이 난다.
+ */
 public class Aes256BlockCipher implements BlockCipher {
 
   private static final String ALGORITHM_NAME = "AES-256";
-  private static final String VERSION = "1.0.0";
+  private static final String VERSION = "1.1.0";
   private static final int BLOCK_SIZE = 16; // 128 bits block size
   private static final int KEY_SIZE = 32; // 256 bits key size
-  private static final String TRANSFORMATION = "AES/ECB/NoPadding";
+  private static final int IV_SIZE = 16; // 128 bits IV size (CBC)
+
+  private final CipherMode mode;
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  /** 기본 생성자. ECB 모드로 동작한다. */
+  public Aes256BlockCipher() {
+    this(CipherMode.ECB);
+  }
+
+  /**
+   * 운영 모드를 지정하여 생성한다.
+   *
+   * @param mode 블록 암호 운영 모드 ({@link CipherMode#ECB} 또는 {@link CipherMode#CBC})
+   */
+  public Aes256BlockCipher(CipherMode mode) {
+    if (mode == null) {
+      throw new IllegalArgumentException("Cipher mode cannot be null");
+    }
+    this.mode = mode;
+  }
 
   @Override
   public String getAlgorithmName() {
@@ -26,6 +62,11 @@ public class Aes256BlockCipher implements BlockCipher {
     return VERSION;
   }
 
+  /** 이 인스턴스의 운영 모드를 반환한다. */
+  public CipherMode getMode() {
+    return mode;
+  }
+
   @Override
   public byte[] encrypt(byte[] plaintext, byte[] key) {
     validateKey(key);
@@ -34,13 +75,17 @@ public class Aes256BlockCipher implements BlockCipher {
     }
 
     byte[] paddedInput = ByteUtils.addPadding(plaintext, BLOCK_SIZE);
-    try {
-      Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-      cipher.init(Cipher.ENCRYPT_MODE, createSecretKey(key));
-      return cipher.doFinal(paddedInput);
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException("Failed to encrypt with AES-256", e);
+    if (mode == CipherMode.ECB) {
+      return doCrypt(Cipher.ENCRYPT_MODE, paddedInput, key, null);
     }
+
+    // CBC: 랜덤 IV 생성 후 [IV][암호문] 형태로 반환
+    byte[] iv = generateIv();
+    byte[] encrypted = doCrypt(Cipher.ENCRYPT_MODE, paddedInput, key, iv);
+    byte[] result = new byte[IV_SIZE + encrypted.length];
+    ByteUtils.copy(iv, 0, result, 0, IV_SIZE);
+    ByteUtils.copy(encrypted, 0, result, IV_SIZE, encrypted.length);
+    return result;
   }
 
   @Override
@@ -49,23 +94,66 @@ public class Aes256BlockCipher implements BlockCipher {
     if (ByteUtils.isEmpty(ciphertext)) {
       throw new IllegalArgumentException("Ciphertext cannot be null or empty");
     }
+
+    if (mode == CipherMode.ECB) {
+      if (ciphertext.length % BLOCK_SIZE != 0) {
+        throw new IllegalArgumentException("Ciphertext length must be a multiple of block size");
+      }
+      return unpad(doCrypt(Cipher.DECRYPT_MODE, ciphertext, key, null));
+    }
+
+    // CBC: 앞 16바이트를 IV로 분리
+    if (ciphertext.length <= IV_SIZE || (ciphertext.length - IV_SIZE) % BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "CBC ciphertext must contain a 16-byte IV followed by a block-size multiple of data");
+    }
+    byte[] iv = new byte[IV_SIZE];
+    byte[] body = new byte[ciphertext.length - IV_SIZE];
+    ByteUtils.copy(ciphertext, 0, iv, 0, IV_SIZE);
+    ByteUtils.copy(ciphertext, IV_SIZE, body, 0, body.length);
+    return unpad(doCrypt(Cipher.DECRYPT_MODE, body, key, iv));
+  }
+
+  /**
+   * IV를 직접 지정해 CBC로 암호화한다. 반환하는 암호문에는 IV가 붙지 않는다.
+   *
+   * @param plaintext 평문
+   * @param key 32바이트 키
+   * @param iv 16바이트 IV
+   * @return 암호문 (IV 미포함)
+   * @throws UnsupportedOperationException ECB 모드에서 호출한 경우
+   */
+  public byte[] encrypt(byte[] plaintext, byte[] key, byte[] iv) {
+    requireCbc();
+    validateKey(key);
+    validateIv(iv);
+    if (plaintext == null) {
+      throw new IllegalArgumentException("Plaintext cannot be null");
+    }
+    byte[] paddedInput = ByteUtils.addPadding(plaintext, BLOCK_SIZE);
+    return doCrypt(Cipher.ENCRYPT_MODE, paddedInput, key, iv);
+  }
+
+  /**
+   * IV를 직접 지정해 CBC로 복호화한다. 암호화 때 쓴 IV를 그대로 넘겨야 한다.
+   *
+   * @param ciphertext 암호문 (IV 미포함)
+   * @param key 32바이트 키
+   * @param iv 암호화에 사용한 16바이트 IV
+   * @return 평문
+   * @throws UnsupportedOperationException ECB 모드에서 호출한 경우
+   */
+  public byte[] decrypt(byte[] ciphertext, byte[] key, byte[] iv) {
+    requireCbc();
+    validateKey(key);
+    validateIv(iv);
+    if (ByteUtils.isEmpty(ciphertext)) {
+      throw new IllegalArgumentException("Ciphertext cannot be null or empty");
+    }
     if (ciphertext.length % BLOCK_SIZE != 0) {
       throw new IllegalArgumentException("Ciphertext length must be a multiple of block size");
     }
-
-    try {
-      Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-      cipher.init(Cipher.DECRYPT_MODE, createSecretKey(key));
-      byte[] decrypted = cipher.doFinal(ciphertext);
-      try {
-        return ByteUtils.removePadding(decrypted, BLOCK_SIZE);
-      } catch (IllegalArgumentException e) {
-        // 패딩이 잘못된 경우에도 디버깅을 위해 복호화된 원본을 반환
-        return decrypted;
-      }
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException("Failed to decrypt with AES-256", e);
-    }
+    return unpad(doCrypt(Cipher.DECRYPT_MODE, ciphertext, key, iv));
   }
 
   @Override
@@ -78,12 +166,62 @@ public class Aes256BlockCipher implements BlockCipher {
     return KEY_SIZE;
   }
 
+  /** 지정된 방향으로 AES 연산을 수행한다. iv가 null이면 ECB, 아니면 CBC 변환을 사용한다. */
+  private byte[] doCrypt(int cipherMode, byte[] input, byte[] key, byte[] iv) {
+    try {
+      Cipher cipher = Cipher.getInstance(transformation());
+      if (iv == null) {
+        cipher.init(cipherMode, createSecretKey(key));
+      } else {
+        cipher.init(cipherMode, createSecretKey(key), new IvParameterSpec(iv));
+      }
+      return cipher.doFinal(input);
+    } catch (GeneralSecurityException e) {
+      throw new RuntimeException("Failed to " + (cipherMode == Cipher.ENCRYPT_MODE ? "encrypt" : "decrypt") + " with AES-256", e);
+    }
+  }
+
+  /** PKCS7 패딩을 제거한다. 패딩이 잘못된 경우 디버깅을 위해 복호화된 원본을 반환한다. */
+  private byte[] unpad(byte[] decrypted) {
+    try {
+      return ByteUtils.removePadding(decrypted, BLOCK_SIZE);
+    } catch (IllegalArgumentException e) {
+      // 패딩이 잘못된 경우에도 디버깅을 위해 복호화된 원본을 반환
+      return decrypted;
+    }
+  }
+
+  private String transformation() {
+    return mode == CipherMode.CBC ? "AES/CBC/NoPadding" : "AES/ECB/NoPadding";
+  }
+
+  private byte[] generateIv() {
+    byte[] iv = new byte[IV_SIZE];
+    secureRandom.nextBytes(iv);
+    return iv;
+  }
+
+  private void requireCbc() {
+    if (mode != CipherMode.CBC) {
+      throw new UnsupportedOperationException("Explicit IV is only supported in CBC mode");
+    }
+  }
+
   private void validateKey(byte[] key) {
     if (ByteUtils.isEmpty(key)) {
       throw new IllegalArgumentException("Key cannot be null or empty");
     }
     if (key.length != KEY_SIZE) {
       throw new IllegalArgumentException("Key must be " + KEY_SIZE + " bytes");
+    }
+  }
+
+  private void validateIv(byte[] iv) {
+    if (ByteUtils.isEmpty(iv)) {
+      throw new IllegalArgumentException("IV cannot be null or empty");
+    }
+    if (iv.length != IV_SIZE) {
+      throw new IllegalArgumentException("IV must be " + IV_SIZE + " bytes");
     }
   }
 

--- a/lib/src/main/java/me/totoku103/crypto/enums/CipherMode.java
+++ b/lib/src/main/java/me/totoku103/crypto/enums/CipherMode.java
@@ -1,0 +1,9 @@
+package me.totoku103.crypto.enums;
+
+/** 블록 암호 운영 모드 */
+public enum CipherMode {
+  /** ECB. IV 없이 동작하며 같은 평문이면 늘 같은 암호문이 나온다. */
+  ECB,
+  /** CBC. 16바이트 IV를 사용한다. */
+  CBC
+}

--- a/lib/src/test/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipherCbcTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipherCbcTest.java
@@ -1,0 +1,317 @@
+package me.totoku103.crypto.algorithms.cipher;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import me.totoku103.crypto.core.utils.ByteUtils;
+import me.totoku103.crypto.enums.CipherMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Aes256BlockCipher CBC 모드를 테스트합니다. */
+@DisplayName("AES-256 CBC 모드")
+class Aes256BlockCipherCbcTest {
+
+  private static final byte[] DEFAULT_KEY =
+      "0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] FIXED_IV = ByteUtils.fromHexString("000102030405060708090a0b0c0d0e0f");
+
+  /** 평문·암호문·복호문을 콘솔에 찍어 눈으로 확인하려고 쓴다. */
+  private static void printRoundTrip(String label, byte[] plaintext, byte[] encrypted, byte[] decrypted) {
+    System.out.println("===== " + label + " =====");
+    System.out.println("  평문      : " + new String(plaintext, StandardCharsets.UTF_8));
+    System.out.println("  평문(hex) : " + ByteUtils.toHexString(plaintext));
+    System.out.println("  암호문(hex): " + ByteUtils.toHexString(encrypted));
+    System.out.println("  복호문    : " + new String(decrypted, StandardCharsets.UTF_8));
+    System.out.println("  복호문(hex): " + ByteUtils.toHexString(decrypted));
+  }
+
+  // ==========================================================================
+  // 2-arg: IV 자동 생성 + prepend
+  // ==========================================================================
+
+  @Test
+  @DisplayName("CBC 2-arg: 암호화/복호화 round-trip")
+  void testCbcAutoIvRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    String plaintext = "Hello, AES-256 CBC mode!";
+    byte[] encrypted = cipher.encrypt(plaintext.getBytes(StandardCharsets.UTF_8), DEFAULT_KEY);
+
+    assertNotNull(encrypted);
+    // [IV(16B)][암호문] 이므로 IV를 제외한 나머지가 블록 크기의 배수여야 한다
+    assertEquals(0, (encrypted.length - cipher.getBlockSize()) % cipher.getBlockSize());
+
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY);
+    printRoundTrip("CBC 2-arg 기본", plaintext.getBytes(StandardCharsets.UTF_8), encrypted, decrypted);
+    assertArrayEquals(plaintext.getBytes(StandardCharsets.UTF_8), decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 한글 round-trip")
+  void testCbcAutoIvKoreanRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    String plaintext = "안녕하세요 AES-256 CBC 테스트입니다!";
+    byte[] encrypted = cipher.encrypt(plaintext.getBytes(StandardCharsets.UTF_8), DEFAULT_KEY);
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY);
+
+    printRoundTrip("CBC 2-arg 한글", plaintext.getBytes(StandardCharsets.UTF_8), encrypted, decrypted);
+    assertArrayEquals(plaintext.getBytes(StandardCharsets.UTF_8), decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 특수문자 round-trip")
+  void testCbcAutoIvSpecialCharactersRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    String plaintext = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~\\ 特殊 🔐🚀 \t\n\r\0";
+    byte[] encrypted = cipher.encrypt(plaintext.getBytes(StandardCharsets.UTF_8), DEFAULT_KEY);
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY);
+
+    printRoundTrip("CBC 2-arg 특수문자", plaintext.getBytes(StandardCharsets.UTF_8), encrypted, decrypted);
+    assertArrayEquals(plaintext.getBytes(StandardCharsets.UTF_8), decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 3-arg: 특수문자 round-trip (고정 IV)")
+  void testCbcExplicitIvSpecialCharactersRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    String plaintext = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~\\ 特殊 🔐🚀 \t\n\r\0";
+    byte[] encrypted = cipher.encrypt(plaintext.getBytes(StandardCharsets.UTF_8), DEFAULT_KEY, FIXED_IV);
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY, FIXED_IV);
+
+    System.out.println("  IV(hex)   : " + ByteUtils.toHexString(FIXED_IV));
+    printRoundTrip("CBC 3-arg 특수문자(고정 IV)", plaintext.getBytes(StandardCharsets.UTF_8), encrypted, decrypted);
+    assertArrayEquals(plaintext.getBytes(StandardCharsets.UTF_8), decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 모든 바이트 값(0x00~0xFF) round-trip")
+  void testCbcAutoIvAllByteValuesRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    byte[] plaintext = new byte[256];
+    for (int i = 0; i < 256; i++) {
+      plaintext[i] = (byte) i;
+    }
+
+    byte[] encrypted = cipher.encrypt(plaintext, DEFAULT_KEY);
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY);
+
+    assertArrayEquals(plaintext, decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 동일 평문+키라도 랜덤 IV로 매번 다른 암호문이 나와야 한다")
+  void testCbcAutoIvIsNonDeterministic() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] plaintext = "Same plaintext, same key".getBytes(StandardCharsets.UTF_8);
+
+    byte[] c1 = cipher.encrypt(plaintext, DEFAULT_KEY);
+    byte[] c2 = cipher.encrypt(plaintext, DEFAULT_KEY);
+
+    assertFalse(Arrays.equals(c1, c2), "랜덤 IV로 인해 두 암호문은 달라야 한다");
+    // 그래도 각각 복호화하면 동일 평문
+    assertArrayEquals(plaintext, cipher.decrypt(c1, DEFAULT_KEY));
+    assertArrayEquals(plaintext, cipher.decrypt(c2, DEFAULT_KEY));
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 출력 앞 16바이트가 실제 사용된 IV여야 한다")
+  void testCbcAutoIvIsPrepended() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] plaintext = "check iv prefix".getBytes(StandardCharsets.UTF_8);
+
+    byte[] encrypted = cipher.encrypt(plaintext, DEFAULT_KEY);
+    byte[] iv = Arrays.copyOfRange(encrypted, 0, 16);
+    byte[] body = Arrays.copyOfRange(encrypted, 16, encrypted.length);
+
+    // 분리한 IV/본문을 3-arg 복호화에 넣으면 동일 평문이 나와야 한다
+    byte[] decrypted = cipher.decrypt(body, DEFAULT_KEY, iv);
+    assertArrayEquals(plaintext, decrypted);
+  }
+
+  // ==========================================================================
+  // 3-arg: 명시적 IV
+  // ==========================================================================
+
+  @Test
+  @DisplayName("CBC 3-arg: 고정 IV round-trip, 결과에 IV가 붙지 않아야 한다")
+  void testCbcExplicitIvRoundTrip() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] plaintext = "explicit iv round trip".getBytes(StandardCharsets.UTF_8);
+
+    byte[] encrypted = cipher.encrypt(plaintext, DEFAULT_KEY, FIXED_IV);
+    // 순수 암호문(패딩 포함)만 반환 → 블록 크기 배수
+    assertEquals(0, encrypted.length % cipher.getBlockSize());
+
+    byte[] decrypted = cipher.decrypt(encrypted, DEFAULT_KEY, FIXED_IV);
+    assertArrayEquals(plaintext, decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 3-arg: 동일 IV+키+평문은 결정적 암호문을 생성해야 한다")
+  void testCbcExplicitIvIsDeterministic() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] plaintext = "deterministic".getBytes(StandardCharsets.UTF_8);
+
+    byte[] c1 = cipher.encrypt(plaintext, DEFAULT_KEY, FIXED_IV);
+    byte[] c2 = cipher.encrypt(plaintext, DEFAULT_KEY, FIXED_IV);
+
+    assertArrayEquals(c1, c2, "동일 IV로 암호화하면 동일 암호문이어야 한다");
+  }
+
+  @Test
+  @DisplayName("CBC 3-arg: 서로 다른 IV는 다른 암호문을 생성해야 한다")
+  void testCbcDifferentIvProducesDifferentCiphertext() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] plaintext = "iv sensitivity".getBytes(StandardCharsets.UTF_8);
+    byte[] iv2 = ByteUtils.fromHexString("0f0e0d0c0b0a09080706050403020100");
+
+    byte[] c1 = cipher.encrypt(plaintext, DEFAULT_KEY, FIXED_IV);
+    byte[] c2 = cipher.encrypt(plaintext, DEFAULT_KEY, iv2);
+
+    assertFalse(Arrays.equals(c1, c2));
+  }
+
+  // ==========================================================================
+  // KAT: NIST SP 800-38A F.2 AES-256-CBC
+  // ==========================================================================
+
+  @Test
+  @DisplayName("NIST SP 800-38A F.2.5 AES-256-CBC KAT: 표준 IV/키/평문 첫 블록이 규격 암호문과 일치해야 한다")
+  void testNistSp80038aCbcKat() {
+    // NIST SP 800-38A Appendix F.2.5 CBC-AES256.Encrypt
+    // key = 603deb1015ca71be2b73aef0857d7781 1f352c073b6108d72d9810a30914dff4
+    // iv  = 000102030405060708090a0b0c0d0e0f
+    // block1 plaintext  = 6bc1bee22e409f96e93d7e117393172a
+    // block1 ciphertext = f58c4c04d6e5f1ba779eabfb5f7bfbd6
+    byte[] key = ByteUtils.fromHexString(
+        "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+    byte[] iv = ByteUtils.fromHexString("000102030405060708090a0b0c0d0e0f");
+    byte[] plaintext = ByteUtils.fromHexString("6bc1bee22e409f96e93d7e117393172a");
+
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] ciphertext = cipher.encrypt(plaintext, key, iv);
+
+    // 16바이트 입력 → PKCS7 패딩으로 32바이트 출력. 첫 블록만 표준 벡터와 비교
+    String firstBlock = ByteUtils.toHexString(ciphertext).substring(0, 32);
+    assertEquals("f58c4c04d6e5f1ba779eabfb5f7bfbd6", firstBlock,
+        "NIST SP 800-38A F.2.5 AES-256-CBC 첫 블록이 표준 KAT 값과 일치해야 한다");
+  }
+
+  // ==========================================================================
+  // 예외 경로
+  // ==========================================================================
+
+  @Test
+  @DisplayName("ECB 모드 인스턴스에서 3-arg encrypt 호출 시 UnsupportedOperationException")
+  void testEcbModeRejectsExplicitIvEncrypt() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.ECB);
+    assertThrows(UnsupportedOperationException.class,
+        () -> cipher.encrypt("x".getBytes(StandardCharsets.UTF_8), DEFAULT_KEY, FIXED_IV));
+  }
+
+  @Test
+  @DisplayName("ECB 모드 인스턴스에서 3-arg decrypt 호출 시 UnsupportedOperationException")
+  void testEcbModeRejectsExplicitIvDecrypt() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.ECB);
+    assertThrows(UnsupportedOperationException.class,
+        () -> cipher.decrypt(new byte[16], DEFAULT_KEY, FIXED_IV));
+  }
+
+  @Test
+  @DisplayName("CBC 3-arg: 잘못된 IV 길이는 IllegalArgumentException")
+  void testCbcInvalidIvLength() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    byte[] shortIv = new byte[8];
+    assertThrows(IllegalArgumentException.class,
+        () -> cipher.encrypt("x".getBytes(StandardCharsets.UTF_8), DEFAULT_KEY, shortIv));
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg decrypt: IV보다 짧은 암호문은 IllegalArgumentException")
+  void testCbcDecryptTooShort() {
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+    assertThrows(IllegalArgumentException.class,
+        () -> cipher.decrypt(new byte[8], DEFAULT_KEY));
+  }
+
+  @Test
+  @DisplayName("생성자에 null 모드 전달 시 IllegalArgumentException")
+  void testNullModeRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new Aes256BlockCipher(null));
+  }
+
+  @Test
+  @DisplayName("getMode: 지정한 모드를 반환해야 한다")
+  void testGetMode() {
+    assertEquals(CipherMode.CBC, new Aes256BlockCipher(CipherMode.CBC).getMode());
+    assertEquals(CipherMode.ECB, new Aes256BlockCipher().getMode());
+  }
+
+  // ==========================================================================
+  // 사용자 입력 암호문 복호화 (직접 값을 넣어 눈으로 확인)
+  // ==========================================================================
+
+  @Test
+  @DisplayName("CBC 3-arg: 사용자가 입력한 암호문(hex)을 고정 IV로 복호화")
+  void testDecryptUserSuppliedCiphertextExplicitIv() {
+    // 확인하려는 암호문(hex)을 넣는다. 비워두면 아래에서 데모 값을 만들어 쓴다.
+    String cipherTextHex = "";
+    byte[] key = DEFAULT_KEY; // 암호화에 썼던 키(32바이트)
+    byte[] iv = FIXED_IV; // 암호화에 썼던 IV(16바이트)
+
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    if (cipherTextHex.isEmpty()) {
+      // 비어 있으면 샘플 평문을 한 번 암호화해서 확인용 암호문을 만든다
+      String demoPlain = "복호화 테스트용 데모 평문 123!@#";
+      cipherTextHex =
+          ByteUtils.toHexString(cipher.encrypt(demoPlain.getBytes(StandardCharsets.UTF_8), key, iv));
+      System.out.println("(암호문 입력이 없어 데모 값으로 대체) " + cipherTextHex);
+    }
+
+    byte[] decrypted = cipher.decrypt(ByteUtils.fromHexString(cipherTextHex), key, iv);
+
+    System.out.println("===== 사용자 입력 암호문 복호화 (3-arg, 고정 IV) =====");
+    System.out.println("  키(hex)   : " + ByteUtils.toHexString(key));
+    System.out.println("  IV(hex)   : " + ByteUtils.toHexString(iv));
+    System.out.println("  암호문(hex): " + cipherTextHex);
+    System.out.println("  복호문    : " + new String(decrypted, StandardCharsets.UTF_8));
+    System.out.println("  복호문(hex): " + ByteUtils.toHexString(decrypted));
+
+    assertNotNull(decrypted);
+  }
+
+  @Test
+  @DisplayName("CBC 2-arg: 사용자가 입력한 암호문(hex, [IV|암호문])을 복호화")
+  void testDecryptUserSuppliedCiphertextPrependedIv() {
+    // 확인하려는 암호문(hex)을 넣는다. 앞 16바이트가 IV인 [IV][암호문] 형식이어야 한다.
+    // (2-arg encrypt가 만든 값. 비워두면 아래에서 데모 값을 만들어 쓴다.)
+    String cipherTextHex = "f3bc9ff7e46ebcfeafd63d5e8adb9bca002f905358f1d43a676e4c7bc0fdcc889f02923758d1645734e10bf655585f22442a4118fc88c155ce7094c12b16443b";
+    byte[] key = DEFAULT_KEY; // 암호화에 썼던 키(32바이트)
+
+    Aes256BlockCipher cipher = new Aes256BlockCipher(CipherMode.CBC);
+
+    if (cipherTextHex.isEmpty()) {
+      String demoPlain = "IV 포함 데모 평문 456$%^";
+      cipherTextHex =
+          ByteUtils.toHexString(cipher.encrypt(demoPlain.getBytes(StandardCharsets.UTF_8), key));
+      System.out.println("(암호문 입력이 없어 데모 값으로 대체) " + cipherTextHex);
+    }
+
+    byte[] decrypted = cipher.decrypt(ByteUtils.fromHexString(cipherTextHex), key);
+
+    System.out.println("===== 사용자 입력 암호문 복호화 (2-arg, IV 포함) =====");
+    System.out.println("  키(hex)   : " + ByteUtils.toHexString(key));
+    System.out.println("  암호문(hex): " + cipherTextHex);
+    System.out.println("  복호문    : " + new String(decrypted, StandardCharsets.UTF_8));
+    System.out.println("  복호문(hex): " + ByteUtils.toHexString(decrypted));
+
+    assertNotNull(decrypted);
+  }
+}

--- a/lib/src/test/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipherTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/algorithms/cipher/Aes256BlockCipherTest.java
@@ -22,7 +22,7 @@ class Aes256BlockCipherTest {
   @Test
   void testGetVersion() {
     Aes256BlockCipher cipher = new Aes256BlockCipher();
-    assertEquals("1.0.0", cipher.getVersion());
+    assertEquals("1.1.0", cipher.getVersion());
   }
 
   @Test

--- a/lib/src/test/java/me/totoku103/crypto/core/factory/CryptoFactoryTest.java
+++ b/lib/src/test/java/me/totoku103/crypto/core/factory/CryptoFactoryTest.java
@@ -78,7 +78,7 @@ class CryptoFactoryTest {
     assertNotNull(cipher);
     assertTrue(cipher instanceof Aes256BlockCipher);
     assertEquals("AES-256", cipher.getAlgorithmName());
-    assertEquals("1.0.0", cipher.getVersion());
+    assertEquals("1.1.0", cipher.getVersion());
     assertEquals(16, cipher.getBlockSize());
     assertEquals(32, cipher.getKeySize());
   }


### PR DESCRIPTION
## 개요
`Aes256BlockCipher`에 CBC 운영 모드를 추가하고 배포 버전을 1.1.0으로 올립니다.

## 변경 사항
### 기능
- `CipherMode` enum(ECB/CBC) 추가, 생성자로 모드 선택(기본 ECB) — 기존 ECB 호출부는 무영향
- CBC IV 처리 두 방식 제공
  - **2-arg** `encrypt/decrypt`: 랜덤 IV 생성 후 `[IV(16B)][암호문]`으로 반환/분리 (호출부가 IV 신경 쓸 필요 없음)
  - **3-arg** `encrypt/decrypt`: IV를 직접 지정, 암호문에 IV 미포함 (ECB 모드에서 호출 시 `UnsupportedOperationException`)
- 클래스 `VERSION` 1.1.0으로 상향

### 테스트
- CBC round-trip(기본/한글/특수문자/전체 바이트값), 랜덤 IV 비결정성, 고정 IV 결정성
- **NIST SP 800-38A F.2.5 AES-256-CBC KAT**
- IV 길이·모드·길이 검증 등 예외 경로
- 사용자가 암호문(hex)을 직접 넣어 복호화 결과를 눈으로 확인하는 테스트

### 릴리즈
- `build.gradle.kts` 배포 버전 1.0.5 → 1.1.0
- 흩어져 있던 버전 문자열 3곳을 `libraryVersion` 변수 하나로 통합

## 검증
- 전체 1100+ 테스트 통과
- `crypto-1.1.0.jar` 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)